### PR TITLE
fix(docs): add zero standard payment warning to FDC

### DIFF
--- a/docs/fdc/attestation-types/balance-decreasing-transaction.mdx
+++ b/docs/fdc/attestation-types/balance-decreasing-transaction.mdx
@@ -42,6 +42,12 @@ A transaction is considered “balance decreasing” for the specified address i
 | `spentAmount`              | `int256`      | Amount spent by the source address in minimal units (can be negative). |
 | `standardPaymentReference` | `bytes32`     | Standardized payment reference of the transaction, if available.       |
 
+:::note[Standard Payment Reference]
+
+If a transaction has no `standardPaymentReference`, it is set to default value, thus, zero value reference should be used with caution.
+
+:::
+
 ## Verification process
 
 1. The transaction identified by `transactionId` is fetched from the **source blockchain node** or a relevant indexer.

--- a/docs/fdc/attestation-types/balance-decreasing-transaction.mdx
+++ b/docs/fdc/attestation-types/balance-decreasing-transaction.mdx
@@ -42,7 +42,7 @@ A transaction is considered “balance decreasing” for the specified address i
 | `spentAmount`              | `int256`      | Amount spent by the source address in minimal units (can be negative). |
 | `standardPaymentReference` | `bytes32`     | Standardized payment reference of the transaction, if available.       |
 
-:::note[Standard Payment Reference]
+:::warning[Standard Payment Reference]
 
 If a transaction has no `standardPaymentReference`, it is set to default value, thus, zero value reference should be used with caution.
 

--- a/docs/fdc/attestation-types/payment.mdx
+++ b/docs/fdc/attestation-types/payment.mdx
@@ -47,7 +47,7 @@ Each supported blockchain specifies how a payment transaction should be formatte
 | `oneToOne`                     | `bool`        | Indicates if the transaction involves only one source and one receiver.                                                        |
 | `status`                       | `uint8`       | [Transaction success status](#transaction-success-status).                                                                     |
 
-:::note[Standard Payment Reference]
+:::warning[Standard Payment Reference]
 
 If a transaction has no `standardPaymentReference`, it is set to default value, thus, zero value reference should be used with caution.
 

--- a/docs/fdc/attestation-types/payment.mdx
+++ b/docs/fdc/attestation-types/payment.mdx
@@ -47,6 +47,12 @@ Each supported blockchain specifies how a payment transaction should be formatte
 | `oneToOne`                     | `bool`        | Indicates if the transaction involves only one source and one receiver.                                                        |
 | `status`                       | `uint8`       | [Transaction success status](#transaction-success-status).                                                                     |
 
+:::note[Standard Payment Reference]
+
+If a transaction has no `standardPaymentReference`, it is set to default value, thus, zero value reference should be used with caution.
+
+:::
+
 ## Verification Process
 
 1. The transaction identified by `transactionId` is fetched from the relevant blockchain node or indexer.


### PR DESCRIPTION
In FDC attestation types Payment and BalanceDecreasingTransaction, users are cautioned of zero standard payment use.