### PR TITLE
fix(docs): fix whitepaper link

### DIFF
--- a/docs/network/guides/secure-random-numbers.mdx
+++ b/docs/network/guides/secure-random-numbers.mdx
@@ -40,7 +40,7 @@ The protocol has an in-built security mechanism to detect manipulation attempts,
 <details>
 <summary>**Understand the mechanism behind secure random numbers on Flare.**</summary>
 
-As described in the [FTSOv2 whitepaper](https://flare.network/wp-content/uploads/FTSOv2-White-Paper.pdf), the Scaling protocol consists of the following phases:
+As described in the [FTSOv2 whitepaper](/pdf/whitepapers/20240223-FlareTimeSeriesOracleV2.pdf), the Scaling protocol consists of the following phases:
 
 1. **Commit:** During the Commit phase, data providers prepare their submissions for each of the data feeds and encode them into a 4-byte vector. Then, each data provider publishes on chain a hash commitment obtained as:
 


### PR DESCRIPTION
There was a broken link in the docs. Check if this is the whitepaper it was supposed to link to.