### PR TITLE
fix(docs): update hardhat-foundry-starter-kit.mdx

### DIFF
--- a/docs/network/guides/hardhat-foundry-starter-kit.mdx
+++ b/docs/network/guides/hardhat-foundry-starter-kit.mdx
@@ -152,7 +152,7 @@ Optionally you can add the API keys for either [Flarescan](https://flarescan.com
   <TabItem value="yarn" label="yarn">
   
     ```bash
-    yarn npx hardhat run scripts/tryDeployment.ts
+    yarn hardhat run scripts/tryDeployment.ts
     ```
 
   </TabItem>


### PR DESCRIPTION
docs: fix incorrect command in deployment script usage

Replaced `yarn npx hardhat run` with the correct `yarn hardhat run` command in the documentation for `tryDeployment.ts` to reflect proper usage.