### PR TITLE
fix(docs): remove security issue in random number example

### DIFF
--- a/examples/developer-hub-solidity/RandomNumberV2Lottery.sol
+++ b/examples/developer-hub-solidity/RandomNumberV2Lottery.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.7.6 <0.9.0;
 
+import {ContractRegistry} from "@flarenetwork/flare-periphery-contracts/coston2/ContractRegistry.sol";
 import {RandomNumberV2Interface} from "@flarenetwork/flare-periphery-contracts/coston2/RandomNumberV2Interface.sol";
 
 /**
@@ -12,8 +13,6 @@ import {RandomNumberV2Interface} from "@flarenetwork/flare-periphery-contracts/c
  * @notice A lottery contract that utilizes a secure random number for determining winners.
  */
 contract LotteryWithRandomNumber {
-    RandomNumberV2Interface internal randomNumberGenerator;
-
     address[] public participants;
     uint256 public lotteryId;
     uint256 public lotteryEndTimestamp;
@@ -25,14 +24,6 @@ contract LotteryWithRandomNumber {
         uint256 randomNumber,
         uint256 timestamp
     );
-
-    /**
-     * @notice Initializes the contract with the address of the random number generator.
-     * @param _randomNumberGenerator The address of the RandomNumberV2Interface contract.
-     */
-    constructor(address _randomNumberGenerator) {
-        randomNumberGenerator = RandomNumberV2Interface(_randomNumberGenerator);
-    }
 
     /**
      * @notice Enter the lottery.
@@ -69,6 +60,8 @@ contract LotteryWithRandomNumber {
         require(participants.length > 0, "No participants in the lottery");
 
         // Get the current random number and its properties
+        RandomNumberV2Interface randomNumberGenerator = ContractRegistry
+            .getRandomNumberV2();
         (
             uint256 randomNumber,
             bool isSecureRandom,

--- a/examples/developer-hub-solidity/SecureRandomConsumer.sol
+++ b/examples/developer-hub-solidity/SecureRandomConsumer.sol
@@ -10,16 +10,6 @@ import {RandomNumberV2Interface} from "@flarenetwork/flare-periphery-contracts/c
  * @dev THIS IS AN EXAMPLE CONTRACT. DO NOT USE THIS EXACT CODE IN PRODUCTION.
  */
 contract SecureRandomConsumer {
-    /// @notice Random number provider (fetched from ContractRegistry at construction).
-    RandomNumberV2Interface public immutable randomV2;
-
-    /**
-     * @notice Initialize and grab the RandomNumberV2 instance from the ContractRegistry.
-     */
-    constructor() {
-        randomV2 = ContractRegistry.getRandomNumberV2();
-    }
-
     /**
      * @notice Returns the latest secure random number.
      * @dev The underlying provider returns `(uint256 random, bool isSecure, uint256 timestamp)`.
@@ -31,6 +21,7 @@ contract SecureRandomConsumer {
         view
         returns (uint256 randomNumber, bool isSecure, uint256 timestamp)
     {
+        RandomNumberV2Interface randomV2 = ContractRegistry.getRandomNumberV2();
         (uint256 _randomNumber, bool _isSecure, uint256 _timestamp) = randomV2
             .getRandomNumber();
 
@@ -51,6 +42,7 @@ contract SecureRandomConsumer {
         view
         returns (uint256 randomNumber, bool isSecure, uint256 timestamp)
     {
+        RandomNumberV2Interface randomV2 = ContractRegistry.getRandomNumberV2();
         (randomNumber, isSecure, timestamp) = randomV2.getRandomNumber();
     }
 }


### PR DESCRIPTION
The address of the `RandomNumberV2 ` contract was set in the constructor, which would break on the `RandomNumberV2` contract update.