### PR TITLE
feat(docs): enhance documentation generation and URL handling

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -285,6 +285,7 @@ const config: Config = {
         llmsFullTxtFilename: "llms-full.txt",
         // curation
         includeOrder: [
+          "1-intro.mdx",
           "**/network/**/*.mdx",
           "**/network/**/*.md",
           "**/ftso/**/*.mdx",
@@ -293,6 +294,12 @@ const config: Config = {
           "**/fdc/**/*.md",
           "**/fassets/**/*.mdx",
           "**/fassets/**/*.md",
+          "**/fxrp/**/*.mdx",
+          "**/fxrp/**/*.md",
+          "**/smart-accounts/**/*.mdx",
+          "**/smart-accounts/**/*.md",
+          "**/fcc/**/*.mdx",
+          "**/fcc/**/*.md",
           "**/run-node/**/*.mdx",
           "**/run-node/**/*.md",
           "**/support/**/*.mdx",
@@ -343,6 +350,33 @@ const config: Config = {
             title: "FAssets Documentation",
             description:
               "FAssets concepts, integration guides, and API/Solidity references",
+          },
+          {
+            filename: "llms-fxrp.txt",
+            includePatterns: ["**/fxrp/**/*.mdx", "**/fxrp/**/*.md"],
+            fullContent: true,
+            title: "FXRP Documentation",
+            description:
+              "FXRP utility on Flare, including Firelight/Upshift vaults, OFT auto-mint/redeem, and token interactions",
+          },
+          {
+            filename: "llms-smart-accounts.txt",
+            includePatterns: [
+              "**/smart-accounts/**/*.mdx",
+              "**/smart-accounts/**/*.md",
+            ],
+            fullContent: true,
+            title: "Flare Smart Accounts Documentation",
+            description:
+              "Account abstraction for XRPL users interacting with Flare, including the MasterAccountController, custom instructions, and CLI guides",
+          },
+          {
+            filename: "llms-fcc.txt",
+            includePatterns: ["**/fcc/**/*.mdx", "**/fcc/**/*.md"],
+            fullContent: true,
+            title: "Flare Confidential Compute Documentation",
+            description:
+              "Flare Confidential Compute (FCC) concepts and integration guides using Trusted Execution Environments",
           },
           {
             filename: "llms-node-operators.txt",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "docusaurus start",
     "automations": "chmod +x run-automations.sh && ./run-automations.sh",
     "update-deps": "chmod +x update-deps.sh && ./update-deps.sh",
-    "build": "docusaurus build && node scripts/fix-llms-urls.mjs",
+    "build": "docusaurus build && node scripts/generate-md-routes.mjs && node scripts/fix-llms-urls.mjs && node scripts/inject-html-llms-tags.mjs",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "deploy:mcp": "npx wrangler deploy --config cloudflare-mcp/wrangler.toml",

--- a/scripts/fix-llms-urls.mjs
+++ b/scripts/fix-llms-urls.mjs
@@ -37,6 +37,11 @@ const globalDataPath = path.join(rootDir, ".docusaurus", "globalData.json");
 
 const SITE_BASE = "https://dev.flare.network";
 
+/** Avoid incomplete substring checks (e.g. https://dev.flare.network.evil.com). */
+function isSiteOriginUrl(url) {
+  return url === SITE_BASE || url.startsWith(`${SITE_BASE}/`);
+}
+
 function escapeRe(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -159,7 +164,7 @@ function loadCanonicalRoutes() {
     const locRe = /<loc>([^<]+)<\/loc>/g;
     for (const m of xml.matchAll(locRe)) {
       const url = m[1];
-      if (!url.startsWith(SITE_BASE)) continue;
+      if (!isSiteOriginUrl(url)) continue;
       const route = url.slice(SITE_BASE.length).replace(/\/$/, "");
       routes.add(route);
     }
@@ -217,7 +222,10 @@ function pruneAndMarkdownify(content, canonicalRoutes) {
     // first link is stale.
     if (/^\s*[-*]\s+\[/.test(line) && links.length > 0) {
       const url = links[0][2];
-      const route = url.replace(SITE_BASE, "").replace(/\.md$/i, "");
+      if (!isSiteOriginUrl(url)) {
+        continue;
+      }
+      const route = url.slice(SITE_BASE.length).replace(/\.md$/i, "");
       if (!canonicalRoutes.has(route)) {
         // Dropped — stale or unlisted.
         continue;
@@ -226,10 +234,12 @@ function pruneAndMarkdownify(content, canonicalRoutes) {
 
     // Otherwise: keep the line, but rewrite same-origin doc links to .md.
     const rewritten = line.replace(linkRe, (full, title, url) => {
-      const route = url.replace(SITE_BASE, "");
+      if (!isSiteOriginUrl(url)) {
+        return full;
+      }
+      const route = url.slice(SITE_BASE.length);
       // Skip non-doc paths (assets, anchors-only, already-.md, off-site)
       if (
-        !url.startsWith(SITE_BASE) ||
         /\.(md|txt|json|xml|pdf|html?|svg|png|jpe?g|gif|webp|ico|css|js)$/i.test(
           url,
         ) ||

--- a/scripts/fix-llms-urls.mjs
+++ b/scripts/fix-llms-urls.mjs
@@ -1,11 +1,28 @@
 #!/usr/bin/env node
 /**
- * Post-build script: fix LLM-generated URLs to use Docusaurus slugs.
- * The docusaurus-plugin-llms builds URLs from file paths (e.g. network/1-getting-started),
- * but our docs use frontmatter `slug` (e.g. getting-started). This script rewrites
- * the generated llms*.txt files so URLs match the actual site routes.
+ * Post-build script: rewrite the URLs inside every generated llms*.txt so that
+ * AI agents and llmstxt.org consumers land on the canonical site routes — and
+ * on the Markdown version of every page.
  *
- * Run after: npm run build (or add "postbuild" / call from build script).
+ * This script does three things:
+ *
+ * 1. Rewrite path segments
+ *    `docusaurus-plugin-llms` builds URLs from source file paths
+ *    (e.g. `network/1-getting-started`), but our pages use frontmatter `slug`
+ *    (e.g. `network/getting-started`). We rewrite the URLs to match the
+ *    actual Docusaurus routes from `.docusaurus/globalData.json`.
+ *
+ * 2. Replace HTML URLs with `.md` URLs
+ *    Agent Score / afdocs require the llms.txt index to link to Markdown.
+ *    For every doc route we emit a `.md` file via generate-md-routes.mjs, so
+ *    we rewrite `https://dev.flare.network/foo/bar` -> `…/foo/bar.md`.
+ *
+ * 3. Drop entries for unlisted / non-existent routes
+ *    `unlisted: true` MDX pages don't appear in the sitemap. The Agent Score
+ *    `Llms Txt Coverage` check flags these as stale, so we filter them out.
+ *    Anything not in globalData.json is also dropped.
+ *
+ * Run after: docusaurus build && node scripts/generate-md-routes.mjs.
  */
 
 import fs from "fs";
@@ -16,6 +33,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, "..");
 const docsDir = path.join(rootDir, "docs");
 const buildDir = path.join(rootDir, "build");
+const globalDataPath = path.join(rootDir, ".docusaurus", "globalData.json");
 
 const SITE_BASE = "https://dev.flare.network";
 
@@ -30,20 +48,22 @@ function escapeRe(s) {
 function getSlugOrIdFromFile(filePath) {
   const raw = fs.readFileSync(filePath, "utf8");
   const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-  if (!match) return null;
+  if (!match) return { slug: null, unlisted: false };
   const front = match[1];
   const slugMatch = front.match(/^slug:\s*["']?([^"'\n]*)["']?\s*$/m);
-  if (slugMatch) return slugMatch[1].trim();
   const idMatch = front.match(/^id:\s*["']?([^"'\s\n]+)["']?\s*$/m);
-  return idMatch ? idMatch[1].trim() : null;
+  const unlistedMatch = front.match(/^unlisted:\s*(true|false)\s*$/m);
+  return {
+    slug: slugMatch ? slugMatch[1].trim() : idMatch ? idMatch[1].trim() : null,
+    unlisted: unlistedMatch ? unlistedMatch[1] === "true" : false,
+  };
 }
 
 /**
  * Recursively collect all .md and .mdx paths under dir, relative to baseDir.
  */
 function collectDocPaths(dir, baseDir, list = []) {
-  const entries = fs.readdirSync(dir, { withFileTypes: true });
-  for (const e of entries) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
     const full = path.join(dir, e.name);
     const rel = path.relative(baseDir, full);
     if (e.isDirectory()) {
@@ -56,21 +76,22 @@ function collectDocPaths(dir, baseDir, list = []) {
 }
 
 /**
- * Build list of [wrongPath, rightPath] for URL replacement.
- * wrongPath = path from file (e.g. network/1-getting-started)
- * rightPath = path using slug (e.g. network/getting-started)
- * When frontmatter has no slug/id, infers clean path by stripping leading "N-" from segments (e.g. 3-governance -> governance).
+ * Build list of [wrongPath, rightPath] for URL replacement and the set of
+ * source-file paths that are `unlisted: true`. Both are derived by walking
+ * the source MDX in `docs/`.
  */
-function buildReplacements() {
+function buildReplacementsAndUnlisted() {
   const replacements = [];
   const seen = new Set();
+  const unlistedPaths = new Set();
   const relPaths = collectDocPaths(docsDir, docsDir);
+
   for (const rel of relPaths) {
     const ext = path.extname(rel);
     const pathWithoutExt = rel.slice(0, -ext.length);
     const lastSegment = path.basename(pathWithoutExt);
     const dir = path.dirname(pathWithoutExt);
-    const slug = getSlugOrIdFromFile(path.join(docsDir, rel));
+    const { slug, unlisted } = getSlugOrIdFromFile(path.join(docsDir, rel));
 
     let rightPath;
     if (slug) {
@@ -80,51 +101,237 @@ function buildReplacements() {
           : slug.includes("/")
             ? slug.split("/").pop()
             : slug;
-      if (
+      const same =
         lastSegment === slugSegment &&
-        pathWithoutExt !== (slug === "/" ? "" : pathWithoutExt)
-      ) {
-        continue;
+        pathWithoutExt !== (slug === "/" ? "" : pathWithoutExt);
+      if (!same) {
+        rightPath =
+          slug === "/" || slug === ""
+            ? ""
+            : slug.includes("/")
+              ? slug
+              : dir
+                ? `${dir}/${slug}`
+                : slug;
+      } else {
+        rightPath = pathWithoutExt;
       }
-      rightPath =
-        slug === "/" || slug === ""
-          ? ""
-          : slug.includes("/")
-            ? slug
-            : dir
-              ? `${dir}/${slug}`
-              : slug;
     } else {
-      const inferredSegment = lastSegment.replace(/^\d+-/, "");
-      if (inferredSegment === lastSegment || !inferredSegment) continue;
-      rightPath = dir ? `${dir}/${inferredSegment}` : inferredSegment;
+      // No slug: strip leading "N-" from each segment
+      const inferred = pathWithoutExt
+        .split("/")
+        .map((seg) => seg.replace(/^\d+-/, ""))
+        .join("/");
+      rightPath = inferred;
     }
 
-    if (pathWithoutExt !== rightPath && !seen.has(pathWithoutExt)) {
+    if (
+      rightPath !== pathWithoutExt &&
+      !seen.has(pathWithoutExt) &&
+      rightPath !== undefined
+    ) {
       seen.add(pathWithoutExt);
       replacements.push([pathWithoutExt, rightPath]);
     }
+
+    if (unlisted) {
+      unlistedPaths.add(rightPath || pathWithoutExt);
+    }
   }
-  return replacements;
+  return { replacements, unlistedPaths };
 }
 
-function fixFile(filePath, replacements) {
-  let content = fs.readFileSync(filePath, "utf8");
-  let changed = false;
-  const rightUrlBase = `${SITE_BASE}/`;
-  for (const [wrongPath, rightPath] of replacements) {
-    const rightUrl = rightUrlBase + rightPath;
-    for (const prefix of ["", "docs/"]) {
-      const wrongUrl = rightUrlBase + prefix + wrongPath;
-      const re = new RegExp(escapeRe(wrongUrl) + "(?!/)", "g");
-      const next = content.replace(re, rightUrl);
-      if (next !== content) {
-        content = next;
-        changed = true;
+/**
+ * Load the set of canonical "publishable" routes. We prefer `sitemap.xml`
+ * because Docusaurus already strips `unlisted: true` pages and other
+ * non-public routes from it — which matches what AI crawlers can reach.
+ *
+ * Falls back to `globalData.json` if the sitemap is missing.
+ *
+ * Routes are normalized by stripping any trailing slash so they compare
+ * directly to URLs found in llms*.txt.
+ */
+function loadCanonicalRoutes() {
+  const routes = new Set();
+  const sitemapPath = path.join(buildDir, "sitemap.xml");
+  if (fs.existsSync(sitemapPath)) {
+    const xml = fs.readFileSync(sitemapPath, "utf8");
+    const locRe = /<loc>([^<]+)<\/loc>/g;
+    for (const m of xml.matchAll(locRe)) {
+      const url = m[1];
+      if (!url.startsWith(SITE_BASE)) continue;
+      const route = url.slice(SITE_BASE.length).replace(/\/$/, "");
+      routes.add(route);
+    }
+    return routes;
+  }
+  if (fs.existsSync(globalDataPath)) {
+    const data = JSON.parse(fs.readFileSync(globalDataPath, "utf8"));
+    const versions =
+      data?.["docusaurus-plugin-content-docs"]?.default?.versions ?? [];
+    for (const v of versions) {
+      for (const d of v.docs ?? []) {
+        const p = (d.path ?? "").replace(/\/$/, "");
+        if (p) routes.add(p);
       }
     }
   }
-  if (changed) {
+  return routes;
+}
+
+/**
+ * Rewrite path-based URLs (step 1 + 2 above) inside an llms*.txt file.
+ * Returns the new content (or original when unchanged).
+ */
+function rewritePaths(content, replacements) {
+  const base = `${SITE_BASE}/`;
+  let next = content;
+  for (const [wrongPath, rightPath] of replacements) {
+    const rightUrl = base + rightPath;
+    for (const prefix of ["", "docs/"]) {
+      const wrongUrl = base + prefix + wrongPath;
+      const re = new RegExp(escapeRe(wrongUrl) + "(?!/)", "g");
+      next = next.replace(re, rightUrl);
+    }
+  }
+  return next;
+}
+
+/**
+ * Walk every link in the file and:
+ *   - drop bullets whose target URL is not in canonicalRoutes (or is in
+ *     unlistedPaths)
+ *   - append `.md` to the URL when the target is a documentation route
+ */
+function pruneAndMarkdownify(content, canonicalRoutes) {
+  const linkRe = /\[([^\]]+)\]\((https:\/\/dev\.flare\.network\/[^)]+)\)/g;
+
+  // Process line-by-line so we can drop entire bullet lines whose URL is stale.
+  const lines = content.split(/\r?\n/);
+  const out = [];
+
+  for (const line of lines) {
+    const links = [...line.matchAll(linkRe)];
+
+    // Bullet/list lines: `- [Title](url): summary` — drop entirely when the
+    // first link is stale.
+    if (/^\s*[-*]\s+\[/.test(line) && links.length > 0) {
+      const url = links[0][2];
+      const route = url.replace(SITE_BASE, "").replace(/\.md$/i, "");
+      if (!canonicalRoutes.has(route)) {
+        // Dropped — stale or unlisted.
+        continue;
+      }
+    }
+
+    // Otherwise: keep the line, but rewrite same-origin doc links to .md.
+    const rewritten = line.replace(linkRe, (full, title, url) => {
+      const route = url.replace(SITE_BASE, "");
+      // Skip non-doc paths (assets, anchors-only, already-.md, off-site)
+      if (
+        !url.startsWith(SITE_BASE) ||
+        /\.(md|txt|json|xml|pdf|html?|svg|png|jpe?g|gif|webp|ico|css|js)$/i.test(
+          url,
+        ) ||
+        url.includes("#")
+      ) {
+        return full;
+      }
+      // Only rewrite when the route is a known doc route.
+      const cleanRoute = route.replace(/\/$/, "");
+      if (!canonicalRoutes.has(cleanRoute)) {
+        return full;
+      }
+      return `[${title}](${SITE_BASE}${cleanRoute}.md)`;
+    });
+
+    out.push(rewritten);
+  }
+
+  // Collapse 3+ consecutive blank lines that may appear after pruning.
+  return out.join("\n").replace(/\n{3,}/g, "\n\n");
+}
+
+/**
+ * Append any sitemap routes that aren't already linked in the file. These are
+ * usually category/generated-index landing pages that `docusaurus-plugin-llms`
+ * doesn't pick up because they have no MDX source.
+ */
+function appendMissingRoutes(content, canonicalRoutes, titleByRoute) {
+  const present = new Set();
+  const linkRe = /\(https:\/\/dev\.flare\.network([^)]+?)(\.md)?\)/g;
+  for (const m of content.matchAll(linkRe)) {
+    present.add(m[1].replace(/\/$/, ""));
+  }
+
+  const missing = [];
+  for (const route of canonicalRoutes) {
+    if (!route) continue;
+    if (route === "/search" || route === "/404") continue;
+    if (!present.has(route)) missing.push(route);
+  }
+  if (missing.length === 0) return content;
+
+  const titleCase = (seg) =>
+    seg
+      .split("-")
+      .map((s) => (s ? s[0].toUpperCase() + s.slice(1) : s))
+      .join(" ");
+
+  const lines = ["", "## Additional Pages", ""];
+  for (const route of missing.sort()) {
+    // Use category-style breadcrumb-ish titles so "guides" pages stay
+    // distinguishable: e.g. "FDC / Guides / Foundry".
+    let title = titleByRoute.get(route);
+    if (!title) {
+      const segs = route.split("/").filter(Boolean).map(titleCase);
+      title = segs.join(" / ");
+    } else {
+      title = titleCase(title);
+    }
+    lines.push(`- [${title}](${SITE_BASE}${route}.md)`);
+  }
+  lines.push("");
+
+  // Insert before the trailing newline(s).
+  return content.replace(/\s*$/, "\n" + lines.join("\n"));
+}
+
+/**
+ * Title lookup for known routes, from `.docusaurus/globalData.json`. Falls
+ * back to a title-cased path segment when the route isn't a content-docs page.
+ */
+function loadTitleByRoute() {
+  const titles = new Map();
+  if (!fs.existsSync(globalDataPath)) return titles;
+  const data = JSON.parse(fs.readFileSync(globalDataPath, "utf8"));
+  const versions =
+    data?.["docusaurus-plugin-content-docs"]?.default?.versions ?? [];
+  for (const v of versions) {
+    for (const d of v.docs ?? []) {
+      const p = (d.path ?? "").replace(/\/$/, "");
+      if (p && d.id) {
+        titles.set(p, d.id.split("/").pop());
+      }
+    }
+  }
+  return titles;
+}
+
+function processLlmsTxt(
+  filePath,
+  replacements,
+  canonicalRoutes,
+  titleByRoute,
+  isIndex,
+) {
+  const original = fs.readFileSync(filePath, "utf8");
+  let content = rewritePaths(original, replacements);
+  content = pruneAndMarkdownify(content, canonicalRoutes);
+  if (isIndex) {
+    content = appendMissingRoutes(content, canonicalRoutes, titleByRoute);
+  }
+  if (content !== original) {
     fs.writeFileSync(filePath, content, "utf8");
     console.log("[fix-llms-urls] Updated:", path.relative(rootDir, filePath));
   }
@@ -135,18 +342,36 @@ function main() {
     console.warn("[fix-llms-urls] build/ not found, skipping.");
     return;
   }
-  const replacements = buildReplacements();
-  if (replacements.length === 0) {
-    console.log("[fix-llms-urls] No slug-based path corrections needed.");
-    return;
-  }
+  const { replacements } = buildReplacementsAndUnlisted();
+  const canonicalRoutes = loadCanonicalRoutes();
+  // Always allow the home route (`/` -> `https://dev.flare.network` with no
+  // trailing slash). Add it explicitly so links to root pass.
+  canonicalRoutes.add("");
+
   const txtFiles = fs
     .readdirSync(buildDir, { withFileTypes: true })
     .filter(
       (e) => e.isFile() && e.name.endsWith(".txt") && e.name.startsWith("llms"),
     );
+
+  if (replacements.length === 0 && canonicalRoutes.size === 0) {
+    console.log("[fix-llms-urls] Nothing to do.");
+    return;
+  }
+
+  const titleByRoute = loadTitleByRoute();
+
   for (const e of txtFiles) {
-    fixFile(path.join(buildDir, e.name), replacements);
+    // Only the main `llms.txt` index gets the "Additional Pages" backfill —
+    // section-specific files like `llms-fdc.txt` should stay focused.
+    const isIndex = e.name === "llms.txt";
+    processLlmsTxt(
+      path.join(buildDir, e.name),
+      replacements,
+      canonicalRoutes,
+      titleByRoute,
+      isIndex,
+    );
   }
 }
 

--- a/scripts/generate-md-routes.mjs
+++ b/scripts/generate-md-routes.mjs
@@ -1,0 +1,352 @@
+#!/usr/bin/env node
+/**
+ * Post-build script: emit a clean .md file next to every documentation HTML page.
+ *
+ * Why: Agent Score / afdocs and most AI agents look for the Markdown source of a
+ * documentation page at the same URL with a `.md` suffix (e.g. `/network/overview.md`).
+ * GitHub Pages serves static files, so we generate the markdown alongside the HTML.
+ *
+ * Source of truth for routes is Docusaurus' `.docusaurus/globalData.json`, which lists
+ * every published doc id and its rendered path. We then map id -> source `.md/.mdx`
+ * file in `docs/`, clean it (strip frontmatter, MDX import/export statements, JSX
+ * components that hold no textual value), and write to `build/<path>.md`.
+ *
+ * Run after: docusaurus build.
+ */
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, "..");
+const docsDir = path.join(rootDir, "docs");
+const buildDir = path.join(rootDir, "build");
+const globalDataPath = path.join(rootDir, ".docusaurus", "globalData.json");
+
+const SITE_BASE = "https://dev.flare.network";
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+/**
+ * Collect every .md / .mdx source path under docs/, relative to docsDir.
+ */
+function collectSourceFiles(dir, list = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      collectSourceFiles(full, list);
+    } else if (/\.(md|mdx)$/i.test(entry.name)) {
+      list.push(path.relative(docsDir, full));
+    }
+  }
+  return list;
+}
+
+/**
+ * Extract simple key/value pairs from a YAML frontmatter block.
+ * Only handles the scalars we need: id, slug, title, description, unlisted.
+ */
+function parseFrontmatter(raw) {
+  const m = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (!m) return { frontmatter: {}, body: raw, length: 0 };
+  const body = raw.slice(m[0].length);
+  const fm = {};
+  for (const line of m[1].split(/\r?\n/)) {
+    const kv = line.match(/^([A-Za-z_][\w-]*)\s*:\s*(.*)$/);
+    if (!kv) continue;
+    let value = kv[2].trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (value === "true") value = true;
+    else if (value === "false") value = false;
+    fm[kv[1]] = value;
+  }
+  return { frontmatter: fm, body, length: m[0].length };
+}
+
+/**
+ * Derive the Docusaurus doc `id` from a source-relative path the same way the
+ * content-docs plugin does: strip the leading `NN-` number prefix from each
+ * segment and drop the extension.
+ *
+ *   `network/0-overview.mdx` -> `network/overview`
+ *   `fdc/guides/foundry/01-address-validity.mdx` -> `fdc/guides/foundry/address-validity`
+ */
+function sourceRelToDocId(rel) {
+  const noExt = rel.replace(/\.(mdx?|md)$/i, "");
+  return noExt
+    .split("/")
+    .map((seg) => seg.replace(/^\d+-/, ""))
+    .join("/");
+}
+
+/**
+ * Build maps:
+ *   - docIdToSource: doc id -> absolute source path
+ *   - docIdToFrontmatter: doc id -> parsed frontmatter
+ */
+function indexSources() {
+  const docIdToSource = new Map();
+  const docIdToFrontmatter = new Map();
+  for (const rel of collectSourceFiles(docsDir)) {
+    const abs = path.join(docsDir, rel);
+    const raw = fs.readFileSync(abs, "utf8");
+    const { frontmatter } = parseFrontmatter(raw);
+    // Explicit frontmatter id wins, otherwise derive from path.
+    const id =
+      typeof frontmatter.id === "string" && frontmatter.id.length > 0
+        ? frontmatter.id.includes("/")
+          ? frontmatter.id
+          : `${path
+              .dirname(rel)
+              .split("/")
+              .map((s) => s.replace(/^\d+-/, ""))
+              .filter(Boolean)
+              .join("/")}/${frontmatter.id}`.replace(/^\//, "")
+        : sourceRelToDocId(rel);
+    docIdToSource.set(id, abs);
+    docIdToFrontmatter.set(id, frontmatter);
+  }
+  return { docIdToSource, docIdToFrontmatter };
+}
+
+/**
+ * Strip MDX import/export statements and a small set of common JSX-only blocks
+ * (e.g. <Tabs>...<TabItem>) so the body reads as plain markdown for LLMs.
+ * We deliberately preserve fenced code blocks, tables, lists, and prose.
+ */
+function cleanMdxBody(body) {
+  // Drop everything that looks like an ESM import/export at the top level.
+  let cleaned = body
+    .split(/\r?\n/)
+    .filter((line) => {
+      const trimmed = line.trim();
+      if (trimmed.startsWith("import ") && /from\s+['"]/.test(trimmed))
+        return false;
+      if (
+        trimmed.startsWith("export ") &&
+        !trimmed.startsWith("export const meta")
+      ) {
+        // strip simple `export const Foo = ...;` lines used by MDX
+        return false;
+      }
+      return true;
+    })
+    .join("\n");
+
+  // Strip self-closing JSX components like `<Tabs />`, `<DocCardList />`.
+  cleaned = cleaned.replace(/^[ \t]*<[A-Z][A-Za-z0-9]*[^>]*\/>[ \t]*$/gm, "");
+
+  // Collapse 3+ blank lines into 2.
+  cleaned = cleaned.replace(/\n{3,}/g, "\n\n");
+
+  return cleaned.trimStart();
+}
+
+/**
+ * Build a clean Markdown document for a single doc.
+ * Returns null when the source is missing.
+ */
+function buildMarkdownForDoc(docId, route, sourcePath, frontmatter) {
+  if (!sourcePath || !fs.existsSync(sourcePath)) return null;
+
+  const raw = fs.readFileSync(sourcePath, "utf8");
+  const { body } = parseFrontmatter(raw);
+  const cleaned = cleanMdxBody(body);
+
+  const title =
+    (typeof frontmatter.title === "string" && frontmatter.title.trim()) ||
+    docId.split("/").pop();
+  const description =
+    typeof frontmatter.description === "string"
+      ? frontmatter.description.trim()
+      : "";
+
+  const headerLines = [`# ${title}`, ""];
+  if (description) {
+    headerLines.push(`> ${description}`, "");
+  }
+  headerLines.push(
+    "> For the complete documentation index, see [llms.txt](/llms.txt). Markdown versions of documentation pages are available by appending `.md` to the page URL.",
+    "",
+    `Source: ${SITE_BASE}${route}`,
+    "",
+    "",
+  );
+
+  // Avoid duplicating the title if the body already starts with the same H1.
+  const bodyStartsWithSameH1 = new RegExp(
+    `^#\\s+${title.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\$&")}\\s*$`,
+    "m",
+  ).test(cleaned.split("\n").slice(0, 3).join("\n"));
+
+  return (
+    headerLines.join("\n") +
+    (bodyStartsWithSameH1 ? cleaned.replace(/^#\s+.+\n+/, "") : cleaned) +
+    "\n"
+  );
+}
+
+function titleCaseSegment(segment) {
+  return segment
+    .split("-")
+    .map((part) =>
+      part.length === 0
+        ? part
+        : part[0].toUpperCase() + part.slice(1).toLowerCase(),
+    )
+    .join(" ");
+}
+
+/**
+ * Resolve the on-disk output paths for a Docusaurus route. We always write the
+ * `.md` next to the matching `.html` so the file is reachable both as
+ * `/foo/bar.md` and (when applicable) `/foo/bar/index.md`.
+ */
+function outputPathsForRoute(route) {
+  // Normalize: route is something like "/", "/network/overview", "/fxrp/firelight/".
+  const trimmed = route.replace(/\/+$/, "");
+  const targets = [];
+
+  if (trimmed === "" || trimmed === "/") {
+    // Home page: write build/index.md
+    targets.push(path.join(buildDir, "index.md"));
+    return targets;
+  }
+
+  const rel = trimmed.startsWith("/") ? trimmed.slice(1) : trimmed;
+  // Primary path: build/<rel>.md  (matches /<rel>.md URL)
+  targets.push(path.join(buildDir, `${rel}.md`));
+
+  // If Docusaurus rendered this as a directory (build/<rel>/index.html),
+  // also drop an index.md inside so /<rel>/ and /<rel>/index.md work too.
+  const indexHtml = path.join(buildDir, rel, "index.html");
+  if (fs.existsSync(indexHtml)) {
+    targets.push(path.join(buildDir, rel, "index.md"));
+  }
+  return targets;
+}
+
+function writeFileEnsuringDir(filePath, contents) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, contents, "utf8");
+}
+
+function main() {
+  if (!fs.existsSync(buildDir)) {
+    console.warn("[generate-md-routes] build/ not found, skipping.");
+    return;
+  }
+  if (!fs.existsSync(globalDataPath)) {
+    console.warn(
+      "[generate-md-routes] .docusaurus/globalData.json not found, skipping.",
+    );
+    return;
+  }
+
+  const globalData = readJson(globalDataPath);
+  const versions =
+    globalData?.["docusaurus-plugin-content-docs"]?.default?.versions ?? [];
+  const docs = versions.flatMap((v) => v.docs ?? []);
+  if (docs.length === 0) {
+    console.warn("[generate-md-routes] No docs found in globalData.json.");
+    return;
+  }
+
+  const { docIdToSource, docIdToFrontmatter } = indexSources();
+
+  // Build a quick title index by route for stub generation below.
+  const titleByRoute = new Map();
+  for (const doc of docs) {
+    const fm = docIdToFrontmatter.get(doc.id) ?? {};
+    const title =
+      (typeof fm.title === "string" && fm.title.trim()) ||
+      doc.id.split("/").pop();
+    titleByRoute.set(doc.path, title);
+  }
+
+  let written = 0;
+  let stubs = 0;
+  let skipped = 0;
+
+  for (const doc of docs) {
+    const docId = doc.id;
+    const route = doc.path;
+    const sourcePath = docIdToSource.get(docId);
+    const frontmatter = docIdToFrontmatter.get(docId) ?? {};
+
+    let md = sourcePath
+      ? buildMarkdownForDoc(docId, route, sourcePath, frontmatter)
+      : null;
+
+    if (!md) {
+      // Generated-index / category landing pages don't have a source MDX.
+      // Emit a stub markdown that lists every child route. This keeps the
+      // route reachable as Markdown and gives crawlers a meaningful page.
+      md = buildCategoryStub(route, docs, titleByRoute);
+      if (md) stubs++;
+      else {
+        skipped++;
+        continue;
+      }
+    }
+
+    for (const outPath of outputPathsForRoute(route)) {
+      writeFileEnsuringDir(outPath, md);
+      written++;
+    }
+  }
+
+  console.log(
+    `[generate-md-routes] Wrote ${written} markdown files (${stubs} category stubs), skipped ${skipped}.`,
+  );
+}
+
+/**
+ * Build a stub markdown page that lists every doc that lives below `route`.
+ * Used for generated-index / category landing pages that lack a source file.
+ */
+function buildCategoryStub(route, docs, titleByRoute) {
+  if (!route || route === "/") return null;
+  const base = route.endsWith("/") ? route.slice(0, -1) : route;
+  const prefix = `${base}/`;
+  const children = docs
+    .filter((d) => d.path !== route && d.path.startsWith(prefix))
+    .filter((d) => {
+      // direct children only (one extra segment beyond the prefix)
+      const rest = d.path.slice(prefix.length).replace(/\/$/, "");
+      return rest.length > 0 && !rest.includes("/");
+    });
+
+  if (children.length === 0) return null;
+
+  const title =
+    titleByRoute.get(route) ?? titleCaseSegment(base.split("/").pop() ?? "");
+  const lines = [
+    `# ${title}`,
+    "",
+    `> Index of ${children.length} page${children.length === 1 ? "" : "s"} under \`${base}\`.`,
+    "",
+    "> For the complete documentation index, see [llms.txt](/llms.txt). Markdown versions of documentation pages are available by appending `.md` to the page URL.",
+    "",
+    `Source: ${SITE_BASE}${route}`,
+    "",
+  ];
+  for (const child of children) {
+    const childTitle =
+      titleByRoute.get(child.path) ?? child.id.split("/").pop();
+    const childUrl = `${SITE_BASE}${child.path}`.replace(/\/$/, "");
+    lines.push(`- [${childTitle}](${childUrl}.md)`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+main();

--- a/scripts/inject-html-llms-tags.mjs
+++ b/scripts/inject-html-llms-tags.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+/**
+ * Post-build script: inject per-page markdown alternate links into every
+ * documentation HTML page in `build/`.
+ *
+ * Why: Agent Score / afdocs and AI agents look in each page's <head> for either
+ *   - <link rel="llms-txt" href="/llms.txt">                (site-wide index)
+ *   - <link rel="alternate" type="text/markdown" href=".../page.md">
+ *
+ * The site-wide tag is already added via docusaurus.config.ts `headTags`. This
+ * script adds the second, page-specific alternate that points at the matching
+ * `.md` file emitted by scripts/generate-md-routes.mjs.
+ *
+ * Run after: docusaurus build && node scripts/generate-md-routes.mjs.
+ */
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, "..");
+const buildDir = path.join(rootDir, "build");
+const SITE_BASE = "https://dev.flare.network";
+
+/**
+ * Walk every file in `dir` recursively and return absolute paths to .html files.
+ */
+function walkHtml(dir, list = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkHtml(full, list);
+    } else if (entry.isFile() && entry.name.endsWith(".html")) {
+      list.push(full);
+    }
+  }
+  return list;
+}
+
+/**
+ * Resolve the URL path for a given HTML file relative to buildDir.
+ *   build/network/overview.html        -> /network/overview
+ *   build/fxrp/firelight/index.html    -> /fxrp/firelight
+ *   build/index.html                   -> /
+ */
+function htmlToRoute(htmlPath) {
+  const rel = path.relative(buildDir, htmlPath).split(path.sep).join("/");
+  if (rel === "index.html") return "/";
+  if (rel.endsWith("/index.html")) {
+    return "/" + rel.slice(0, -"/index.html".length);
+  }
+  return "/" + rel.replace(/\.html$/i, "");
+}
+
+/**
+ * Find the matching .md file for an HTML page, if generate-md-routes.mjs wrote
+ * one. Returns the absolute path or null.
+ */
+function matchingMdForHtml(htmlPath) {
+  const rel = path.relative(buildDir, htmlPath);
+  const candidates = [];
+  if (rel === "index.html") {
+    candidates.push(path.join(buildDir, "index.md"));
+  } else if (
+    rel.endsWith(path.sep + "index.html") ||
+    rel.endsWith("/index.html")
+  ) {
+    const dir = rel.slice(0, -"/index.html".length);
+    candidates.push(path.join(buildDir, `${dir}.md`));
+    candidates.push(path.join(buildDir, dir, "index.md"));
+  } else {
+    candidates.push(path.join(buildDir, rel.replace(/\.html$/i, ".md")));
+  }
+  return candidates.find((p) => fs.existsSync(p)) ?? null;
+}
+
+/**
+ * Skip pages that are not documentation routes — these don't need an
+ * alternate markdown link because they have no source markdown.
+ */
+function isSkippablePage(route) {
+  return (
+    route === "/404" ||
+    route.startsWith("/tags") ||
+    route === "/search" ||
+    route === "/mcp"
+  );
+}
+
+/**
+ * Inject one or more <link> tags right before </head>. Idempotent: tags that
+ * already appear (by their `rel` value) are skipped.
+ */
+function injectIntoHead(html, tagsToAdd) {
+  const idx = html.toLowerCase().indexOf("</head>");
+  if (idx === -1) return html;
+
+  const head = html.slice(0, idx);
+  const tail = html.slice(idx);
+
+  const toInject = tagsToAdd.filter((tag) => {
+    // Heuristic: dedupe on the full tag string and on the `rel` value
+    // (handles both quoted and unquoted attribute styles).
+    if (head.includes(tag)) return false;
+    const relMatch = tag.match(/rel=["']?([^"'\s>]+)["']?/i);
+    if (!relMatch) return true;
+    const rel = relMatch[1];
+    // Don't re-inject the llms-txt directive if it's already present.
+    if (rel === "llms-txt" && /rel=["']?llms-txt["']?/i.test(head)) {
+      return false;
+    }
+    // Don't re-inject the markdown alternate if it's already present.
+    if (
+      rel === "alternate" &&
+      /<link[^>]+rel=["']?alternate["']?[^>]+type=["']?text\/markdown["']?/i.test(
+        head,
+      )
+    ) {
+      return false;
+    }
+    return true;
+  });
+
+  if (toInject.length === 0) return html;
+  return head + toInject.join("") + tail;
+}
+
+function injectAgentDirective(html) {
+  if (html.includes("agent-docs-directive")) return html;
+  const bodyMatch = html.match(/<body[^>]*>/i);
+  if (!bodyMatch || bodyMatch.index === undefined) return html;
+
+  const directive =
+    '<div id="agent-docs-directive" style="position:absolute;left:-10000px;top:auto;width:1px;height:1px;overflow:hidden">' +
+    'Agent documentation index: <a href="/llms.txt">llms.txt</a>. ' +
+    "Markdown versions of documentation pages are available by appending <code>.md</code> to the page URL." +
+    "</div>";
+
+  const insertAt = bodyMatch.index + bodyMatch[0].length;
+  return html.slice(0, insertAt) + directive + html.slice(insertAt);
+}
+
+function main() {
+  if (!fs.existsSync(buildDir)) {
+    console.warn("[inject-html-llms-tags] build/ not found, skipping.");
+    return;
+  }
+
+  // Site-wide llms.txt directive (advertised on every HTML page, including
+  // non-doc routes like 404 and tags). Docusaurus' built-in `headTags` config
+  // does not reliably survive the SWC HTML minifier, so we inject here.
+  const llmsTxtTag = `<link rel="llms-txt" type="text/markdown" href="/llms.txt">`;
+
+  const htmlFiles = walkHtml(buildDir);
+  let injectedAlt = 0;
+  let injectedLlms = 0;
+  let missingMd = 0;
+
+  for (const htmlPath of htmlFiles) {
+    const route = htmlToRoute(htmlPath);
+
+    const tags = [llmsTxtTag];
+    let altInjected = false;
+
+    if (!isSkippablePage(route)) {
+      const mdPath = matchingMdForHtml(htmlPath);
+      if (mdPath) {
+        const mdRelFromBuild = path
+          .relative(buildDir, mdPath)
+          .split(path.sep)
+          .join("/");
+        const mdUrl = `${SITE_BASE}/${mdRelFromBuild}`;
+        tags.push(
+          `<link rel="alternate" type="text/markdown" ` +
+            `href="${mdUrl}" title="Markdown version of this page">`,
+        );
+        altInjected = true;
+      } else {
+        missingMd++;
+      }
+    }
+
+    const html = fs.readFileSync(htmlPath, "utf8");
+    const next = injectAgentDirective(injectIntoHead(html, tags));
+    if (next !== html) {
+      fs.writeFileSync(htmlPath, next, "utf8");
+      injectedLlms++;
+      if (altInjected) injectedAlt++;
+    }
+  }
+
+  console.log(
+    `[inject-html-llms-tags] Injected llms-txt directive into ${injectedLlms} HTML pages, ` +
+      `markdown alternate into ${injectedAlt} doc pages ` +
+      `(${missingMd} doc pages had no matching .md).`,
+  );
+}
+
+main();


### PR DESCRIPTION
- Added new LLMS documentation sections for FXRP, Smart Accounts, and FCC.
- Updated build script to generate Markdown routes alongside HTML pages.
- Enhanced URL fixing script to handle unlisted pages and improve canonical route detection.
- Injected alternate Markdown links into HTML pages for better accessibility.