### PR TITLE
feat(docs): add NOWNodes to developer tools RPC list

### DIFF
--- a/src/features/DeveloperTools/developer-tools.json
+++ b/src/features/DeveloperTools/developer-tools.json
@@ -1,6 +1,7 @@
 {
   "toolDescriptions": {
     "QuickNode": "High-performance APIs for queries, transactions, and cross-chain operations.",
+    "NOWNodes": "Flare Full Node RPC service built for developers, enterprises, and Web3 applications.",
     "Envio": "A modern, multi-chain EVM blockchain indexer for querying real-time and historical data.",
     "Ankr": "Infrastructure and developer tools for blockchain application deployment.",
     "Thirdweb": "SDK for building, launching, and managing Web3 applications with minimal configuration.",
@@ -60,6 +61,10 @@
           {
             "name": "QuickNode",
             "link": "https://www.quicknode.com/chains/flare"
+          },
+          {
+            "name": "NOWNodes",
+            "link": "https://nownodes.io/"
           },
           {
             "name": "Ankr",
@@ -199,6 +204,10 @@
             "link": "https://www.quicknode.com/chains/flare"
           },
           {
+            "name": "NOWNodes",
+            "link": "https://nownodes.io/"
+          },
+          {
             "name": "Ankr",
             "link": "https://www.ankr.com/rpc/flare/"
           },
@@ -269,6 +278,10 @@
         "Bridges": [],
         "RPCs": [
           {
+            "name": "NOWNodes",
+            "link": "https://nownodes.io/"
+          },
+          {
             "name": "Ankr",
             "link": "https://www.ankr.com/rpc/flare/"
           },
@@ -331,6 +344,10 @@
       "categories": {
         "Bridges": [],
         "RPCs": [
+          {
+            "name": "NOWNodes",
+            "link": "https://nownodes.io/"
+          },
           {
             "name": "Ankr",
             "link": "https://www.ankr.com/rpc/flare/"


### PR DESCRIPTION
## Summary

Adds [NOWNodes](https://nownodes.io/) to the curated RPC providers on the [Developer Tools](https://developer.flare.network/network/developer-tools) page for Flare Mainnet, Coston2, Songbird, and Coston.

## Changes

- `developer-tools.json`: NOWNodes card link and description text for the provider list across networks.

Made with [Cursor](https://cursor.com)