### PR TITLE
docs(flare-entity): add c-chain-indexer-db (MySQL) to the verify-deployment checklist

### DIFF
--- a/docs/run-node/5-flare-entity.mdx
+++ b/docs/run-node/5-flare-entity.mdx
@@ -693,6 +693,7 @@ Once your services are up, follow these steps to confirm everything is running s
    Ensure these key containers appear in the list and have `Up` status:
    - `system-client`
    - `c-chain-indexer`
+   - `c-chain-indexer-db` (MySQL backing store for the C-Chain Indexer)
    - `fast-updates-client` (if enabled)
    - `ftso-client`
    - `fdc-client`


### PR DESCRIPTION
### What

Adds the `c-chain-indexer-db` (MySQL) container to the **Verify deployment success** checklist in the "Set Up Flare Entity" guide.

### Why

The `flare-systems-deployment` `docker-compose.yaml` defines a dedicated `c-chain-indexer-db` service (`image: mysql:9.5.0`) as the backing store for the `c-chain-indexer`:

```yaml
  c-chain-indexer-db:
    image: "mysql:9.5.0@sha256:57c892dd..."
  ...
  c-chain-indexer:
    ...
```

After `docker compose up -d`, this MySQL container is part of the running stack, but the guide's verify checklist lists only `system-client`, `c-chain-indexer`, `fast-updates-client`, `ftso-client`, and `fdc-client` — so an operator following the guide has no way to know a MySQL container is expected, and can't confirm it's `Up`. This addition makes the checklist match what `docker ps` actually shows.

No other content changed.
